### PR TITLE
Properly pass options to HttpClient

### DIFF
--- a/src/InoOicClient/Oic/AbstractHttpRequestDispatcher.php
+++ b/src/InoOicClient/Oic/AbstractHttpRequestDispatcher.php
@@ -139,6 +139,7 @@ abstract class AbstractHttpRequestDispatcher
     public function sendHttpRequest(Http\Request $httpRequest)
     {
         $this->setLastHttpRequest($httpRequest);
+        $this->httpClient->setOptions($this->options->get(self::OPT_HTTP_OPTIONS, array()));
         
         try {
             $httpResponse = $this->httpClient->send($httpRequest);

--- a/src/InoOicClient/Oic/Token/Dispatcher.php
+++ b/src/InoOicClient/Oic/Token/Dispatcher.php
@@ -30,7 +30,7 @@ class Dispatcher extends AbstractHttpRequestDispatcher
     public function getHttpRequestBuilder()
     {
         if (! $this->httpRequestBuilder instanceof HttpRequestBuilder) {
-            $this->httpRequestBuilder = new HttpRequestBuilder($this->options->get(self::OPT_HTTP_OPTIONS, array()));
+            $this->httpRequestBuilder = new HttpRequestBuilder();
         }
         return $this->httpRequestBuilder;
     }


### PR DESCRIPTION
This lived at https://github.com/ivan-novakov/php-openid-connect-client/pull/11 prior to forking.